### PR TITLE
fix: add missing dependency for curl

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
     npm \
     pkg-config \
     libssl-dev \
+    libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Starship


### PR DESCRIPTION
In order to be able to use the new CORE server in the sandbox,
this commit adds the missing dependency for using <curl/curl.h>.

closes #25