### PR TITLE
install node v22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,6 +12,10 @@ RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+RUN apt remove -y nodejs npm libnode-dev
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+RUN apt install -y nodejs
+
 # Install Starship
 RUN curl -sS https://starship.rs/install.sh | sh -s -- --yes
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,12 +10,10 @@ RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
     libcurl4-openssl-dev \
+    && apt remove -y nodejs npm libnode-dev \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
-
-RUN apt remove -y nodejs npm libnode-dev
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-RUN apt install -y nodejs
-
 # Install Starship
 RUN curl -sS https://starship.rs/install.sh | sh -s -- --yes
 


### PR DESCRIPTION
visualizer does not work with the antique version that comes by default with ubuntu, therefore we have to manually install v22